### PR TITLE
Create Nuxt 3 portfolio scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+node_modules
+.nuxt
+.output
+.cache
+.DS_Store
+*.log
+.env
+.env.*

--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# Nuxt 3 Portfolio Starter
+
+This repository contains a Nuxt 3 project scaffold for a personal portfolio site.
+
+## Available Pages
+
+- **Top** (`/`) – Landing page with animated copy that redirects to the profile.
+- **Profile** (`/profile`) – Space to introduce yourself.
+- **Portfolio** (`/portfolio`) – Placeholder project showcase.
+- **Contact** (`/contact`) – Simple contact information and form layout.
+
+## Getting Started
+
+```bash
+# Install dependencies
+npm install
+
+# Start a development server
+npm run dev
+
+# Build for production
+npm run build
+
+# Preview the production build
+npm run preview
+```
+
+> **Note:** The project targets Node.js 18 or newer, which aligns with the Nuxt 3 requirements.

--- a/app.vue
+++ b/app.vue
@@ -1,0 +1,5 @@
+<template>
+  <NuxtLayout>
+    <NuxtPage />
+  </NuxtLayout>
+</template>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,0 +1,58 @@
+:root {
+  --color-background: #0f172a;
+  --color-surface: rgba(15, 23, 42, 0.6);
+  --color-text: #e2e8f0;
+  --color-accent: #38bdf8;
+  --max-width: 960px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Noto Sans JP', 'Inter', system-ui, -apple-system, BlinkMacSystemFont,
+    'Segoe UI', sans-serif;
+  background: radial-gradient(circle at top, #1e293b, #0f172a 65%);
+  color: var(--color-text);
+  min-height: 100vh;
+}
+
+a {
+  color: var(--color-accent);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+main {
+  padding: 4rem 1.5rem 3rem;
+}
+
+section {
+  margin: 0 auto;
+  max-width: var(--max-width);
+}
+
+h1,
+ h2,
+ h3,
+ h4 {
+  font-family: 'Figtree', 'Noto Sans JP', sans-serif;
+  font-weight: 700;
+  margin: 0 0 1rem;
+}
+
+p {
+  line-height: 1.7;
+  margin: 0 0 1rem;
+}
+
+button,
+input,
+textarea {
+  font-family: inherit;
+}

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,0 +1,106 @@
+<script setup lang="ts">
+const currentYear = new Date().getFullYear();
+</script>
+
+<template>
+  <div class="app-shell">
+    <header class="site-header">
+      <NuxtLink to="/" class="brand">My Portfolio</NuxtLink>
+      <nav class="site-nav">
+        <NuxtLink to="/profile">Profile</NuxtLink>
+        <NuxtLink to="/portfolio">Portfolio</NuxtLink>
+        <NuxtLink to="/contact">Contact</NuxtLink>
+      </nav>
+    </header>
+
+    <main>
+      <slot />
+    </main>
+
+    <footer class="site-footer">
+      <small>&copy; {{ currentYear }} My Portfolio. All rights reserved.</small>
+    </footer>
+  </div>
+</template>
+
+<style scoped>
+.app-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.25rem 1.5rem;
+  background: rgba(15, 23, 42, 0.85);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.brand {
+  font-size: 1.125rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1.25rem;
+  font-weight: 600;
+}
+
+.site-nav :deep(a) {
+  color: var(--color-text);
+  position: relative;
+  transition: color 0.2s ease;
+}
+
+.site-nav :deep(a)::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  bottom: -0.35rem;
+  width: 100%;
+  height: 2px;
+  background: var(--color-accent);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.2s ease;
+}
+
+.site-nav :deep(a):hover::after,
+.site-nav :deep(.router-link-active)::after {
+  transform: scaleX(1);
+}
+
+main {
+  flex: 1;
+}
+
+.site-footer {
+  margin-top: auto;
+  padding: 2rem 1.5rem 3rem;
+  text-align: center;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+@media (max-width: 640px) {
+  .site-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
+
+  .site-nav {
+    width: 100%;
+    justify-content: space-between;
+  }
+}
+</style>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,0 +1,16 @@
+export default defineNuxtConfig({
+  devtools: { enabled: true },
+  css: ['~/assets/css/main.css'],
+  app: {
+    head: {
+      title: 'Portfolio Site',
+      meta: [
+        {
+          name: 'description',
+          content:
+            'Nuxt 3-based portfolio site with top, profile, portfolio, and contact pages.'
+        }
+      ]
+    }
+  }
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "portfolio-site",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "nuxt dev",
+    "build": "nuxt build",
+    "generate": "nuxt generate",
+    "preview": "nuxt preview",
+    "postinstall": "nuxt prepare"
+  },
+  "devDependencies": {
+    "nuxt": "^3.12.3"
+  }
+}

--- a/pages/contact.vue
+++ b/pages/contact.vue
@@ -1,0 +1,145 @@
+<script setup lang="ts">
+const contactInfo = [
+  { label: 'Email', value: 'hello@example.com' },
+  { label: 'Location', value: 'Tokyo, Japan' },
+  { label: 'Availability', value: 'Open for freelance and full-time roles' }
+];
+
+useHead({
+  title: 'Contact | Portfolio Site'
+});
+</script>
+
+<template>
+  <section class="contact">
+    <h1>Contact</h1>
+    <p>
+      お仕事のご依頼やご相談は下記フォーム、またはメールアドレスからお気軽にご連絡ください。
+    </p>
+
+    <div class="contact__grid">
+      <aside class="contact__info">
+        <h2>Info</h2>
+        <dl>
+          <template v-for="item in contactInfo" :key="item.label">
+            <dt>{{ item.label }}</dt>
+            <dd>{{ item.value }}</dd>
+          </template>
+        </dl>
+      </aside>
+
+      <form class="contact__form">
+        <label>
+          お名前
+          <input type="text" name="name" placeholder="山田 太郎" required />
+        </label>
+        <label>
+          メールアドレス
+          <input type="email" name="email" placeholder="you@example.com" required />
+        </label>
+        <label>
+          メッセージ
+          <textarea name="message" rows="5" placeholder="お問い合わせ内容をご記入ください" required></textarea>
+        </label>
+        <button type="submit">Send Message</button>
+      </form>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.contact {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.contact__grid {
+  display: grid;
+  grid-template-columns: minmax(220px, 280px) 1fr;
+  gap: 2rem;
+}
+
+.contact__info {
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 20px;
+  padding: 1.75rem;
+}
+
+.contact__info dl {
+  margin: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.contact__info dt {
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.9);
+}
+
+.contact__info dd {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.contact__form {
+  display: grid;
+  gap: 1.25rem;
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 20px;
+  padding: 2rem;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.35);
+}
+
+.contact__form label {
+  display: grid;
+  gap: 0.5rem;
+  font-weight: 600;
+}
+
+.contact__form input,
+.contact__form textarea {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.9);
+  color: var(--color-text);
+}
+
+.contact__form input:focus,
+.contact__form textarea:focus {
+  outline: none;
+  border-color: rgba(56, 189, 248, 0.75);
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.25);
+}
+
+.contact__form button {
+  justify-self: start;
+  padding: 0.75rem 1.75rem;
+  border-radius: 999px;
+  border: none;
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.9), rgba(14, 165, 233, 0.9));
+  color: #0f172a;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.contact__form button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 25px rgba(56, 189, 248, 0.35);
+}
+
+@media (max-width: 860px) {
+  .contact__grid {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,0 +1,118 @@
+<script setup lang="ts">
+const router = useRouter();
+const heroLines = [
+  'クリエイティブを形にし',
+  'ストーリーを届ける',
+  'ポートフォリオへようこそ'
+];
+let redirectTimer: ReturnType<typeof setTimeout> | null = null;
+
+useHead({
+  title: 'Top | Portfolio Site'
+});
+
+onMounted(() => {
+  redirectTimer = setTimeout(() => {
+    router.push('/profile');
+  }, 4500);
+});
+
+onBeforeUnmount(() => {
+  if (redirectTimer) {
+    clearTimeout(redirectTimer);
+  }
+});
+</script>
+
+<template>
+  <section class="hero">
+    <div class="hero__content">
+      <p class="eyebrow">Welcome</p>
+      <h1 class="headline">
+        <span
+          v-for="(line, index) in heroLines"
+          :key="line"
+          class="headline__line"
+          :style="{ animationDelay: `${index * 0.75}s` }"
+        >
+          {{ line }}
+        </span>
+      </h1>
+      <p class="subcopy">
+        数秒後にプロフィールページへ遷移します。スクロールやナビゲーションで他のページにもアクセスできます。
+      </p>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.hero {
+  min-height: calc(100vh - 140px);
+  display: grid;
+  place-items: center;
+  text-align: center;
+}
+
+.hero__content {
+  backdrop-filter: blur(16px);
+  background: rgba(15, 23, 42, 0.55);
+  padding: 3.5rem 3rem;
+  border-radius: 24px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: 0 25px 55px rgba(15, 23, 42, 0.55);
+}
+
+.eyebrow {
+  letter-spacing: 0.42em;
+  text-transform: uppercase;
+  font-size: 0.8rem;
+  font-weight: 600;
+  margin-bottom: 1.5rem;
+  color: rgba(148, 163, 184, 0.9);
+}
+
+.headline {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  margin: 0 0 1.5rem;
+  font-size: clamp(2.3rem, 6vw, 3.75rem);
+  line-height: 1.15;
+}
+
+.headline__line {
+  opacity: 0;
+  transform: translateY(25px);
+  animation: rise-and-glow 0.85s ease forwards;
+}
+
+.subcopy {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.8);
+}
+
+@keyframes rise-and-glow {
+  0% {
+    opacity: 0;
+    transform: translateY(25px);
+  }
+  60% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  100% {
+    opacity: 1;
+    text-shadow: 0 0 25px rgba(56, 189, 248, 0.45);
+  }
+}
+
+@media (max-width: 600px) {
+  .hero {
+    padding: 2rem 1rem;
+  }
+
+  .hero__content {
+    padding: 2.5rem 1.75rem;
+  }
+}
+</style>

--- a/pages/portfolio.vue
+++ b/pages/portfolio.vue
@@ -1,0 +1,122 @@
+<script setup lang="ts">
+interface ProjectSummary {
+  title: string;
+  description: string;
+  role: string;
+  tags: string[];
+}
+
+const projects: ProjectSummary[] = [
+  {
+    title: 'ブランドサイト リニューアル',
+    description:
+      'コンセプト設計からUIデザイン、フロントエンド実装までを担当。滑らかなアニメーションとレスポンシブ対応でブランド価値を訴求。',
+    role: 'Lead Designer & Frontend',
+    tags: ['Nuxt 3', 'GSAP', 'Design System']
+  },
+  {
+    title: 'モバイルアプリ LP',
+    description:
+      'アプリのコア体験を短時間で伝えるランディングページを制作。ヒーローアニメーションと実際の画面モックアップで理解を促進。',
+    role: 'UI Designer',
+    tags: ['Vue', 'Motion Design', 'Copywriting']
+  },
+  {
+    title: 'グローバルイベント サイト',
+    description:
+      '世界各地の参加者向けに多言語対応したイベントサイトを構築。CMSと連携し、運用チームがコンテンツを素早く更新できる仕組みを実装。',
+    role: 'Frontend Engineer',
+    tags: ['Nuxt', 'i18n', 'Headless CMS']
+  }
+];
+
+useHead({
+  title: 'Portfolio | Portfolio Site'
+});
+</script>
+
+<template>
+  <section class="portfolio">
+    <header class="portfolio__intro">
+      <h1>Portfolio</h1>
+      <p>
+        実績の一例です。実際の制作物やスクリーンショット、成果指標などを追加して魅力的なショーケースに仕上げてください。
+      </p>
+    </header>
+
+    <div class="portfolio__list">
+      <article v-for="project in projects" :key="project.title" class="project-card">
+        <div class="project-card__header">
+          <h2>{{ project.title }}</h2>
+          <span class="project-card__role">{{ project.role }}</span>
+        </div>
+        <p>{{ project.description }}</p>
+        <ul class="project-card__tags">
+          <li v-for="tag in project.tags" :key="tag">{{ tag }}</li>
+        </ul>
+      </article>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.portfolio {
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+.portfolio__intro {
+  max-width: 680px;
+}
+
+.portfolio__list {
+  display: grid;
+  gap: 1.75rem;
+}
+
+.project-card {
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 20px;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.4);
+}
+
+.project-card__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.75rem;
+  justify-content: space-between;
+}
+
+.project-card__role {
+  font-size: 0.875rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.9);
+}
+
+.project-card__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.project-card__tags li {
+  background: rgba(56, 189, 248, 0.15);
+  border: 1px solid rgba(56, 189, 248, 0.4);
+  color: #bae6fd;
+  padding: 0.35rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+}
+</style>

--- a/pages/profile.vue
+++ b/pages/profile.vue
@@ -1,0 +1,83 @@
+<script setup lang="ts">
+const skills = [
+  'UI/UXデザイン',
+  'Webフロントエンド開発',
+  'アニメーション実装',
+  'ブランドコミュニケーション'
+];
+
+useHead({
+  title: 'Profile | Portfolio Site'
+});
+</script>
+
+<template>
+  <section class="profile">
+    <h1>Profile</h1>
+    <p>
+      ここに自己紹介文が入ります。経歴や得意分野、制作におけるこだわりなどを自由に加筆してポートフォリオの核となる情報を伝えましょう。
+    </p>
+
+    <div class="profile__grid">
+      <article class="profile__card">
+        <h2>About</h2>
+        <p>
+          デザインと開発の両面から体験設計を行うフロントエンドエンジニアです。ビジュアルと使いやすさのバランスを大切に、ブランドストーリーを魅力的に伝えるUIを設計します。
+        </p>
+      </article>
+      <article class="profile__card">
+        <h2>Skills</h2>
+        <ul>
+          <li v-for="skill in skills" :key="skill">{{ skill }}</li>
+        </ul>
+      </article>
+      <article class="profile__card">
+        <h2>Values</h2>
+        <p>
+          ユーザー視点で課題を捉え、素早いプロトタイピングと継続的な改善で最適解を導きます。チームとのコミュニケーションを重視し、共通のビジョンを形にすることがモットーです。
+        </p>
+      </article>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.profile {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.profile__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
+}
+
+.profile__card {
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 20px;
+  padding: 1.75rem;
+  box-shadow: 0 15px 35px rgba(15, 23, 42, 0.45);
+}
+
+.profile__card h2 {
+  margin-bottom: 0.75rem;
+}
+
+.profile__card ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.profile__card li::before {
+  content: '•';
+  color: var(--color-accent);
+  margin-right: 0.5rem;
+}
+</style>

--- a/project
+++ b/project
@@ -1,1 +1,0 @@
-codextest

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <defs>
+    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#38bdf8" />
+      <stop offset="100%" stop-color="#0ea5e9" />
+    </linearGradient>
+  </defs>
+  <rect width="128" height="128" rx="28" fill="#0f172a" />
+  <path
+    d="M36 91L55 37h18l20 54h-16l-4-12H56l-4 12H36zm29-22h10l-5-16-5 16z"
+    fill="url(#g)"
+  />
+</svg>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./.nuxt/tsconfig.json"
+}


### PR DESCRIPTION
## Summary
- initialize a Nuxt 3 project structure tailored for a portfolio website
- add animated top page plus profile, portfolio, and contact routes with starter copy and styling
- include shared layout, global styles, and project documentation for running the app

## Testing
- npm install *(fails: 403 Forbidden when reaching npm registry in the provided environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfa5b9c57c832c9211a7ac8ebb6675