### PR TITLE
Style profile page to match provided design

### DIFF
--- a/layouts/profile.vue
+++ b/layouts/profile.vue
@@ -1,0 +1,232 @@
+<script setup lang="ts">
+const route = useRoute();
+
+const menuItems = [
+  { label: 'Profile', to: '/profile' },
+  { label: 'Portfolio', to: '/portfolio' },
+  { label: 'Contact', to: '/contact' }
+];
+</script>
+
+<template>
+  <div class="profile-layout">
+    <div class="profile-layout__glow profile-layout__glow--one" aria-hidden="true"></div>
+    <div class="profile-layout__glow profile-layout__glow--two" aria-hidden="true"></div>
+
+    <header class="profile-layout__header">
+      <p class="profile-layout__subtitle">I am</p>
+      <h1 class="profile-layout__title">PIKICHAN.</h1>
+    </header>
+
+    <main class="profile-layout__main">
+      <slot />
+    </main>
+
+    <nav class="profile-layout__menu" aria-label="Main navigation">
+      <span class="profile-layout__menu-line" aria-hidden="true"></span>
+      <ul>
+        <li v-for="item in menuItems" :key="item.to">
+          <NuxtLink :to="item.to" :class="{ active: route.path === item.to }">
+            <span>{{ item.label }}</span>
+          </NuxtLink>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</template>
+
+<style scoped>
+.profile-layout {
+  position: relative;
+  min-height: 100vh;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: clamp(2.5rem, 6vw, 4.5rem) clamp(1.5rem, 6vw, 4.5rem) clamp(3rem, 8vw, 5.5rem);
+  background: radial-gradient(140% 95% at 10% 5%, rgba(255, 255, 255, 0.25) 0%, rgba(56, 119, 255, 0.2) 38%, rgba(19, 40, 112, 0.85) 100%),
+    linear-gradient(140deg, #7fb3ff 0%, #4679f5 48%, #1c2d80 100%);
+  color: #f8fbff;
+}
+
+.profile-layout::before,
+.profile-layout::after {
+  content: '';
+  position: absolute;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.45);
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+.profile-layout::before {
+  width: clamp(360px, 50vw, 520px);
+  height: clamp(360px, 50vw, 520px);
+  left: clamp(-220px, -14vw, -120px);
+  top: clamp(40px, 12vh, 120px);
+  border-bottom-color: transparent;
+  border-right-color: transparent;
+  transform: rotate(-15deg);
+}
+
+.profile-layout::after {
+  width: clamp(220px, 38vw, 360px);
+  height: clamp(220px, 38vw, 360px);
+  left: clamp(-120px, -10vw, -60px);
+  top: clamp(320px, 26vh, 380px);
+  border-left-color: transparent;
+  border-top-color: transparent;
+  transform: rotate(-30deg);
+}
+
+.profile-layout__glow {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(120px);
+  opacity: 0.45;
+  pointer-events: none;
+}
+
+.profile-layout__glow--one {
+  width: clamp(280px, 40vw, 520px);
+  height: clamp(280px, 40vw, 520px);
+  top: clamp(-120px, -8vw, -40px);
+  right: clamp(-120px, -10vw, -40px);
+  background: rgba(135, 200, 255, 0.5);
+}
+
+.profile-layout__glow--two {
+  width: clamp(320px, 55vw, 640px);
+  height: clamp(320px, 55vw, 640px);
+  bottom: clamp(-220px, -12vw, -80px);
+  right: clamp(-200px, -16vw, -60px);
+  background: rgba(54, 119, 255, 0.35);
+}
+
+.profile-layout__header {
+  text-align: center;
+  margin-bottom: clamp(2rem, 5vw, 3.5rem);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  z-index: 1;
+}
+
+.profile-layout__subtitle {
+  font-size: clamp(1rem, 2.4vw, 1.5rem);
+  margin: 0 0 0.25rem;
+  font-weight: 500;
+  opacity: 0.85;
+}
+
+.profile-layout__title {
+  font-size: clamp(2.5rem, 6vw, 3.75rem);
+  margin: 0;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+}
+
+.profile-layout__main {
+  width: min(980px, 100%);
+  z-index: 1;
+}
+
+.profile-layout__menu {
+  position: absolute;
+  top: 50%;
+  right: clamp(0.5rem, 4vw, 3.5rem);
+  transform: translateY(-50%);
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  z-index: 1;
+}
+
+.profile-layout__menu-line {
+  display: block;
+  width: 1px;
+  height: clamp(160px, 32vh, 240px);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0.8) 48%, rgba(255, 255, 255, 0) 100%);
+}
+
+.profile-layout__menu ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.profile-layout__menu a {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.7);
+  letter-spacing: 0.35em;
+  text-transform: uppercase;
+  font-size: 0.82rem;
+  transition: color 0.2s ease;
+  transform: rotate(90deg);
+}
+
+.profile-layout__menu a::after {
+  content: '';
+  position: absolute;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.6);
+  bottom: -18px;
+  left: 50%;
+  transform: translateX(-50%);
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+.profile-layout__menu a:hover,
+.profile-layout__menu a:focus-visible,
+.profile-layout__menu a.active {
+  color: #ffffff;
+}
+
+.profile-layout__menu a.active::after,
+.profile-layout__menu a:hover::after,
+.profile-layout__menu a:focus-visible::after {
+  opacity: 1;
+}
+
+@media (max-width: 900px) {
+  .profile-layout__menu {
+    position: static;
+    transform: none;
+    margin-top: clamp(3rem, 9vw, 4.5rem);
+  }
+
+  .profile-layout__menu-line {
+    display: none;
+  }
+
+  .profile-layout__menu a {
+    transform: none;
+    letter-spacing: 0.08em;
+  }
+
+  .profile-layout__menu ul {
+    flex-direction: row;
+    gap: 1.25rem;
+  }
+}
+
+@media (max-width: 640px) {
+  .profile-layout {
+    padding: 2.5rem 1.25rem 3.5rem;
+  }
+
+  .profile-layout__title {
+    letter-spacing: 0.1em;
+  }
+}
+</style>

--- a/pages/profile.vue
+++ b/pages/profile.vue
@@ -1,83 +1,420 @@
 <script setup lang="ts">
-const skills = [
-  'UI/UXデザイン',
-  'Webフロントエンド開発',
-  'アニメーション実装',
-  'ブランドコミュニケーション'
+definePageMeta({
+  layout: 'profile'
+});
+
+const socials = [
+  {
+    label: 'Twitter',
+    icon: 'tw',
+    href: 'https://twitter.com/'
+  },
+  {
+    label: 'Instagram',
+    icon: 'ig',
+    href: 'https://www.instagram.com/'
+  },
+  {
+    label: 'Dribbble',
+    icon: 'dr',
+    href: 'https://dribbble.com/'
+  },
+  {
+    label: 'Behance',
+    icon: 'be',
+    href: 'https://www.behance.net/'
+  }
 ];
 
-useHead({
-  title: 'Profile | Portfolio Site'
-});
+const expertise = ['UI/UXデザイン', 'Webマーケティング', 'モーション作成', 'ブランド開発'];
+
+const interests = ['プロダクトグロース', 'コミュニティデザイン', 'ソーシャルグッド', 'アートディレクション'];
+
+const summaryText =
+  '直感的で楽しいプロダクトをつくることが使命です。データドリブンな分析と、ユーザーインサイトから導く発想を両軸に、ビジュアルと言葉の体験を滑らかにつなげることを大切にしています。企画から実装、改善までを横断しながら、ブランドに息を吹き込むような表現を探求しています。';
+
+const talkText =
+  '新規事業やサービス改善のアイデアについて、お互いのこだわりや熱量を共有しながら形にしていく時間が好きです。まずはラフな相談からでも大歓迎ですので、気軽に声をかけてください。';
+
+const mottoText = '「たのしいは、伝播する。」ひとりが感じたワクワクが連鎖してチーム全体の推進力になると信じています。まずは自分が楽しむことから。';
 </script>
 
 <template>
-  <section class="profile">
-    <h1>Profile</h1>
-    <p>
-      ここに自己紹介文が入ります。経歴や得意分野、制作におけるこだわりなどを自由に加筆してポートフォリオの核となる情報を伝えましょう。
-    </p>
+  <section class="profile-page">
+    <div class="profile-card">
+      <figure class="profile-card__photo">
+        <img src="/profile-hero.svg" alt="プロフィールのビジュアル" />
+      </figure>
 
-    <div class="profile__grid">
-      <article class="profile__card">
-        <h2>About</h2>
-        <p>
-          デザインと開発の両面から体験設計を行うフロントエンドエンジニアです。ビジュアルと使いやすさのバランスを大切に、ブランドストーリーを魅力的に伝えるUIを設計します。
-        </p>
-      </article>
-      <article class="profile__card">
-        <h2>Skills</h2>
-        <ul>
-          <li v-for="skill in skills" :key="skill">{{ skill }}</li>
+      <div class="profile-card__identity">
+        <div class="profile-card__name">
+          <h2>
+            山田 飛衣
+            <span class="profile-card__roman">(YAMADA HIRAKI)</span>
+          </h2>
+          <ul class="profile-card__meta" aria-label="プロフィールの基本情報">
+            <li>
+              <span class="meta-label">Age</span>
+              <span class="meta-value">23 <span class="meta-note">[1999/07/17]</span></span>
+            </li>
+            <li>
+              <span class="meta-label">From</span>
+              <span class="meta-value">Tokyo, Japan</span>
+            </li>
+          </ul>
+        </div>
+        <ul class="profile-card__socials" aria-label="ソーシャルリンク">
+          <li v-for="social in socials" :key="social.label">
+            <a :href="social.href" target="_blank" rel="noreferrer noopener">
+              <span aria-hidden="true">{{ social.icon }}</span>
+              <span class="sr-only">{{ social.label }}</span>
+            </a>
+          </li>
         </ul>
-      </article>
-      <article class="profile__card">
-        <h2>Values</h2>
-        <p>
-          ユーザー視点で課題を捉え、素早いプロトタイピングと継続的な改善で最適解を導きます。チームとのコミュニケーションを重視し、共通のビジョンを形にすることがモットーです。
-        </p>
-      </article>
+      </div>
+
+      <div class="profile-card__role">
+        <span class="chip chip--label">ROLE</span>
+        <p>Product Developer</p>
+      </div>
+
+      <div class="profile-card__details">
+        <section class="info-block info-block--summary">
+          <header>
+            <span class="chip">サマリー</span>
+          </header>
+          <p>{{ summaryText }}</p>
+        </section>
+
+        <section class="info-block info-block--expertise">
+          <header>
+            <span class="chip">得意なこと</span>
+          </header>
+          <ul class="chip-list" aria-label="得意分野">
+            <li v-for="item in expertise" :key="item">{{ item }}</li>
+          </ul>
+        </section>
+
+        <section class="info-block info-block--interests">
+          <header>
+            <span class="chip">興味があること</span>
+          </header>
+          <ul class="chip-list" aria-label="興味のあるテーマ">
+            <li v-for="item in interests" :key="item">{{ item }}</li>
+          </ul>
+        </section>
+
+        <section class="info-block info-block--talk">
+          <header>
+            <span class="chip">お話しましょう</span>
+          </header>
+          <p>{{ talkText }}</p>
+        </section>
+
+        <section class="info-block info-block--motto">
+          <header>
+            <span class="chip">好きなフレーズ</span>
+          </header>
+          <p>{{ mottoText }}</p>
+        </section>
+
+        <section class="info-block info-block--cta">
+          <header>
+            <span class="chip">ギャラリー</span>
+          </header>
+          <p>制作プロセスやラフスケッチはギャラリーページで公開中です。</p>
+          <NuxtLink to="/portfolio" class="cta-button">ギャラリーを見る</NuxtLink>
+        </section>
+      </div>
     </div>
   </section>
 </template>
 
 <style scoped>
-.profile {
-  display: flex;
-  flex-direction: column;
-  gap: 2rem;
-}
-
-.profile__grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  gap: 1.5rem;
-}
-
-.profile__card {
-  background: rgba(15, 23, 42, 0.6);
-  border: 1px solid rgba(148, 163, 184, 0.25);
-  border-radius: 20px;
-  padding: 1.75rem;
-  box-shadow: 0 15px 35px rgba(15, 23, 42, 0.45);
-}
-
-.profile__card h2 {
-  margin-bottom: 0.75rem;
-}
-
-.profile__card ul {
-  list-style: none;
-  padding: 0;
+.profile-page {
   margin: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
+  max-width: none;
 }
 
-.profile__card li::before {
-  content: '•';
-  color: var(--color-accent);
-  margin-right: 0.5rem;
+.profile-card {
+  position: relative;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.95) 0%, rgba(245, 249, 255, 0.95) 100%);
+  border-radius: clamp(28px, 4vw, 36px);
+  padding: clamp(2rem, 5vw, 3.5rem) clamp(1.75rem, 5vw, 3.5rem) clamp(2.5rem, 6vw, 4rem);
+  box-shadow: 0 45px 80px rgba(28, 60, 150, 0.22);
+  color: #1a2659;
+  overflow: hidden;
+}
+
+.profile-card__photo {
+  margin: 0;
+  border-radius: clamp(22px, 3vw, 28px);
+  overflow: hidden;
+  box-shadow: inset 0 0 0 1px rgba(26, 38, 89, 0.08);
+}
+
+.profile-card__photo img {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.profile-card__identity {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: clamp(1.5rem, 4vw, 3rem);
+  margin-top: clamp(1.75rem, 4vw, 2.75rem);
+  flex-wrap: wrap;
+}
+
+.profile-card__name {
+  flex: 1;
+  min-width: 260px;
+}
+
+.profile-card__name h2 {
+  font-size: clamp(1.8rem, 4.2vw, 2.4rem);
+  margin: 0 0 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+}
+
+.profile-card__roman {
+  font-size: clamp(0.9rem, 2.1vw, 1.1rem);
+  font-weight: 500;
+  margin-left: 0.65rem;
+  color: rgba(26, 38, 89, 0.6);
+  letter-spacing: 0.08em;
+}
+
+.profile-card__meta {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: clamp(0.75rem, 2vw, 1.5rem);
+  margin: 0;
+  padding: 0;
+}
+
+.profile-card__meta li {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  font-size: 0.95rem;
+  letter-spacing: 0.05em;
+}
+
+.meta-label {
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: rgba(26, 38, 89, 0.45);
+}
+
+.meta-value {
+  font-weight: 600;
+}
+
+.meta-note {
+  font-size: 0.75em;
+  color: rgba(26, 38, 89, 0.55);
+  margin-left: 0.35em;
+}
+
+.profile-card__socials {
+  list-style: none;
+  display: flex;
+  gap: 0.75rem;
+  margin: 0;
+  padding: 0;
+}
+
+.profile-card__socials a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: #e4edff;
+  color: #315ed9;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  box-shadow: inset 0 0 0 1px rgba(49, 94, 217, 0.12);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.profile-card__socials a:hover,
+.profile-card__socials a:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: inset 0 0 0 1px rgba(49, 94, 217, 0.45), 0 12px 18px rgba(49, 94, 217, 0.25);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.profile-card__role {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-top: clamp(2rem, 5vw, 3rem);
+  margin-bottom: clamp(1.5rem, 4vw, 2.5rem);
+  font-size: clamp(1.05rem, 2.4vw, 1.25rem);
+  letter-spacing: 0.04em;
+}
+
+.profile-card__role p {
+  margin: 0;
+  font-weight: 600;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  background: #e7edff;
+  color: #2543a5;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+}
+
+.chip--label {
+  background: #2543a5;
+  color: #ffffff;
+  letter-spacing: 0.4em;
+}
+
+.profile-card__details {
+  display: grid;
+  grid-template-columns: minmax(0, 1.9fr) minmax(0, 1fr);
+  gap: clamp(1.75rem, 4vw, 2.75rem) clamp(1.5rem, 4vw, 2.75rem);
+}
+
+.info-block {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  font-size: 0.98rem;
+  line-height: 1.8;
+  letter-spacing: 0.04em;
+}
+
+.info-block--summary {
+  grid-row: span 2;
+}
+
+.info-block--talk {
+  grid-column: 1 / 2;
+}
+
+.info-block--motto {
+  grid-column: 1 / -1;
+  border-top: 1px solid rgba(37, 67, 165, 0.1);
+  padding-top: clamp(1.5rem, 4vw, 2.25rem);
+}
+
+.info-block--cta {
+  grid-column: 2 / 3;
+  align-items: flex-start;
+  gap: 1.25rem;
+}
+
+.chip-list {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  margin: 0;
+  padding: 0;
+}
+
+.chip-list li {
+  padding: 0.4rem 0.85rem;
+  border-radius: 999px;
+  background: rgba(39, 84, 210, 0.08);
+  color: #2543a5;
+  font-weight: 600;
+  font-size: 0.85rem;
+  letter-spacing: 0.05em;
+}
+
+.cta-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: linear-gradient(130deg, #5a8fff, #6bd2ff);
+  color: #ffffff;
+  border-radius: 999px;
+  padding: 0.75rem 2.1rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  box-shadow: 0 18px 28px rgba(66, 126, 242, 0.35);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.cta-button::after {
+  content: '\2192';
+  font-size: 1.1rem;
+}
+
+.cta-button:hover,
+.cta-button:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 22px 34px rgba(66, 126, 242, 0.42);
+}
+
+@media (max-width: 960px) {
+  .profile-card__details {
+    grid-template-columns: 1fr;
+  }
+
+  .info-block--summary {
+    grid-row: auto;
+  }
+
+  .info-block--cta {
+    grid-column: auto;
+  }
+
+  .info-block--motto {
+    grid-column: auto;
+  }
+}
+
+@media (max-width: 640px) {
+  .profile-card__socials {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .profile-card__identity {
+    flex-direction: column;
+  }
+
+  .profile-card__role {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .chip {
+    letter-spacing: 0.24em;
+  }
 }
 </style>

--- a/public/profile-hero.svg
+++ b/public/profile-hero.svg
@@ -1,0 +1,39 @@
+<svg width="1200" height="640" viewBox="0 0 1200 640" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">PIKICHAN abstract portrait</title>
+  <desc id="desc">An abstract illustration with gradients and soft shapes in blue colors.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#6aa9ff" />
+      <stop offset="45%" stop-color="#4f7dff" />
+      <stop offset="100%" stop-color="#273c8f" />
+    </linearGradient>
+    <linearGradient id="face" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#ffe6d9" />
+      <stop offset="50%" stop-color="#f9c9b4" />
+      <stop offset="100%" stop-color="#f0a693" />
+    </linearGradient>
+    <linearGradient id="shirt" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#3c52af" />
+      <stop offset="100%" stop-color="#18245f" />
+    </linearGradient>
+    <filter id="soft" x="-20%" y="-20%" width="140%" height="140%" filterUnits="objectBoundingBox">
+      <feGaussianBlur stdDeviation="40" result="blur" />
+      <feBlend in="SourceGraphic" in2="blur" mode="screen" />
+    </filter>
+  </defs>
+  <rect width="1200" height="640" rx="48" fill="url(#bg)" />
+  <g opacity="0.36" filter="url(#soft)">
+    <circle cx="200" cy="120" r="220" fill="#ffffff" />
+    <circle cx="1070" cy="520" r="210" fill="#7bc6ff" />
+    <circle cx="980" cy="140" r="150" fill="#8dd9ff" />
+  </g>
+  <g transform="translate(330 90)">
+    <ellipse cx="270" cy="348" rx="270" ry="170" fill="url(#shirt)" />
+    <ellipse cx="270" cy="190" rx="170" ry="170" fill="url(#face)" />
+    <path d="M130 110c32-62 104-102 173-102s141 40 173 102c18 36 27 80 18 121-48 22-109 35-191 35s-142-13-190-35c-10-41-2-85 17-121z" fill="#2b1e1f" opacity="0.9" />
+    <ellipse cx="210" cy="170" rx="24" ry="26" fill="#1f1416" opacity="0.9" />
+    <ellipse cx="330" cy="170" rx="24" ry="26" fill="#1f1416" opacity="0.9" />
+    <path d="M240 220c12 14 30 22 48 22s36-8 48-22" fill="none" stroke="#1f1416" stroke-width="10" stroke-linecap="round" />
+    <path d="M132 298c48 54 105 76 170 76s122-22 170-76" fill="none" stroke="#f8a89d" stroke-width="20" stroke-linecap="round" />
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- add a dedicated profile layout with gradient background, decorative rings, and rotated navigation to mirror the provided mock
- rebuild the profile page markup and styling to match the design’s card layout, typography, and content structure
- include an abstract profile illustration asset used at the top of the card

## Testing
- ⚠️ `npm install` *(fails: registry access returns 403 Forbidden in container)*
- ⚠️ `npm run build` *(fails: nuxt command missing because dependencies could not be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68cfb04e9594832cb74cd9cd4bac4df9